### PR TITLE
Flutter 3.0 Migration

### DIFF
--- a/lib/ticker_text.dart
+++ b/lib/ticker_text.dart
@@ -77,7 +77,7 @@ class TickerText extends StatefulWidget {
         super(key: key);
 
   @override
-  _TickerTextState createState() => _TickerTextState();
+  State<TickerText> createState() => _TickerTextState();
 }
 
 class _TickerTextState extends State<TickerText> {
@@ -96,7 +96,7 @@ class _TickerTextState extends State<TickerText> {
         widget.controller ?? TickerTextController(autoStart: true);
 
     if (_autoScrollController.started) {
-      WidgetsBinding.instance?.addPostFrameCallback((_) => _scroll());
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scroll());
     } else {
       _autoScrollController.addListener(_scroll);
     }
@@ -115,9 +115,9 @@ class _TickerTextState extends State<TickerText> {
     return FadingEdgeScrollView.fromSingleChildScrollView(
       child: SingleChildScrollView(
         physics: const NeverScrollableScrollPhysics(),
-        child: widget.child,
         scrollDirection: widget.scrollDirection,
         controller: _scrollController,
+        child: widget.child,
       ),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -42,21 +42,21 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   fading_edge_scrollview:
     dependency: "direct main"
     description:
       name: fading_edge_scrollview
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.0"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -68,7 +68,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -80,14 +80,21 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.4"
   meta:
     dependency: transitive
     description:
@@ -101,7 +108,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -113,7 +120,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -148,21 +155,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.9"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,21 +1,21 @@
 name: ticker_text
 description: Configurable & straightforward text scroller with minimal dependencies.
-version: 1.0.0
+version: 2.0.0
 homepage: https://github.com/arafatamim/ticker_text
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  sdk: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"
 
 dependencies:
-  fading_edge_scrollview: ^2.0.1
+  fading_edge_scrollview: ^3.0.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
WidgetsBinding.instance is not nullable in flutter 3.0.
fading_edge_scrollview migration landed in version 3.0.0

@arafatamim